### PR TITLE
Auth0Backend now checks kwargs for standard user info fields

### DIFF
--- a/django_auth0/auth_backend.py
+++ b/django_auth0/auth_backend.py
@@ -5,15 +5,36 @@ from django.utils.translation import ugettext as _
 
 UserModel = get_user_model()
 
+# user profile keys that are always present as specified by
+# https://auth0.com/docs/user-profile/normalized#normalized-user-profile-schema
+AUTH0_USER_INFO_KEYS = [
+    'name',
+    'nickname',
+    'picture',
+    'user_id',
+]
+
 
 class Auth0Backend(object):
     def authenticate(self, **kwargs):
         """
         Auth0 return a dict which contains the following fields
-        :param email: user email
-        :param username: username
+        :param kwargs: user information provided by auth0
         :return: user
         """
+
+        is_auth0 = True
+
+        # check that each auth0 key is present in kwargs
+        for key in AUTH0_USER_INFO_KEYS:
+            if key not in kwargs:
+                is_auth0 = False
+                break
+
+        # End the authentication attempt if this is not an auth0 payload
+        if is_auth0 is False:
+            return None
+
         email = kwargs.pop('email')
         username = kwargs.pop('nickname')
 

--- a/tests/test_auth_backend.py
+++ b/tests/test_auth_backend.py
@@ -16,7 +16,10 @@ class TestDjangoAuth0(TestCase):
         self.backend = Auth0Backend()
         self.auth_data = {
             'email': 'email@email.com',
-            'nickname': 'test_username'
+            'nickname': 'test_username',
+            'name': 'Test User',
+            'picture': 'http://localhost/test.png',
+            'user_id': 'auth0|1111111',
         }
 
     def test_authenticate_works(self):
@@ -32,8 +35,14 @@ class TestDjangoAuth0(TestCase):
     def test_authenticate_fires_exception(self):
         """ Authenticate fires exception when insufficient data supplied """
         self.assertRaises(ValueError, self._value_error)
-        self.assertRaises(KeyError, self.backend.authenticate)
 
     def _value_error(self):
         self.auth_data['email'] = None
         return self.backend.authenticate(**self.auth_data)
+
+    def test_authenticate_ignores_non_auth0(self):
+        """
+        Auth0Backend.authenticate() will ignore attempts to authenticate
+        that do not contain the user info fields that are always provided by auth0
+        """
+        self.assertIsNone(self.backend.authenticate())


### PR DESCRIPTION
This is to fix #4 

I've made `AUTH0_USER_INFO_KEYS` which contains the common user info properties that will [always be provided](https://auth0.com/docs/user-profile/normalized#normalized-user-profile-schema) by auth0.

Please let me know what you think.

Thanks!
