### PR TITLE
Update AuthBackend

### DIFF
--- a/django_auth0/auth_backend.py
+++ b/django_auth0/auth_backend.py
@@ -5,15 +5,36 @@ from django.utils.translation import ugettext as _
 
 UserModel = get_user_model()
 
+# user profile keys that are always present as specified by
+# https://auth0.com/docs/user-profile/normalized#normalized-user-profile-schema
+AUTH0_USER_INFO_KEYS = [
+    'name',
+    'nickname',
+    'picture',
+    'user_id',
+]
+
 
 class Auth0Backend(object):
     def authenticate(self, **kwargs):
         """
         Auth0 return a dict which contains the following fields
-        :param email: user email
-        :param username: username
+        :param kwargs: user information provided by auth0
         :return: user
         """
+
+        is_auth0 = True
+
+        # check that each auth0 key is present in kwargs
+        for key in AUTH0_USER_INFO_KEYS:
+            if key not in kwargs:
+                is_auth0 = False
+                break
+
+        # End the authentication attempt if this is not an auth0 payload
+        if is_auth0 is False:
+            return None
+
         email = kwargs.pop('email')
         username = kwargs.pop('nickname')
 

--- a/django_auth0/auth_backend.py
+++ b/django_auth0/auth_backend.py
@@ -22,7 +22,6 @@ class Auth0Backend(object):
         :param kwargs: user information provided by auth0
         :return: user
         """
-
         is_auth0 = True
 
         # check that each auth0 key is present in kwargs
@@ -35,18 +34,22 @@ class Auth0Backend(object):
         if is_auth0 is False:
             return None
 
-        email = kwargs.pop('email')
-        username = kwargs.pop('nickname')
+        user_id = kwargs.get('user_id')
 
-        if username and email:
-            try:
-                return UserModel.objects.get(email__iexact=email,
-                                             username__iexact=username)
-            except UserModel.DoesNotExist:
-                return UserModel.objects.create(email=email,
-                                                username=username)
+        if user_id is None:
+            raise ValueError(_('user_id can\'t be blank!'))
 
-        raise ValueError(_('Username or email can\'t be blank'))
+        # The format of user_id is {identity provider id}|{unique id in the provider}
+        # The pipe character is invalid for the django username field
+        # The solution is to replace the pipe with a dash
+        username = user_id.replace('|', '-')
+
+        try:
+            user = UserModel.objects.get(username__iexact=username)
+        except UserModel.DoesNotExist:
+            user = UserModel.objects.create(username=username)
+
+        return user
 
     # noinspection PyProtectedMember
     def get_user(self, user_id):

--- a/tests/test_auth_backend.py
+++ b/tests/test_auth_backend.py
@@ -16,7 +16,10 @@ class TestDjangoAuth0(TestCase):
         self.backend = Auth0Backend()
         self.auth_data = {
             'email': 'email@email.com',
-            'nickname': 'test_username'
+            'nickname': 'test_username',
+            'name': 'Test User',
+            'picture': 'http://localhost/test.png',
+            'user_id': 'auth0|1111111',
         }
 
     def test_authenticate_works(self):
@@ -32,8 +35,14 @@ class TestDjangoAuth0(TestCase):
     def test_authenticate_fires_exception(self):
         """ Authenticate fires exception when insufficient data supplied """
         self.assertRaises(ValueError, self._value_error)
-        self.assertRaises(KeyError, self.backend.authenticate)
 
     def _value_error(self):
         self.auth_data['email'] = None
         return self.backend.authenticate(**self.auth_data)
+
+    def test_authenticate_ignores_non_auth0(self):
+        """
+        Auth0Backend.authenticate() will ignore attempts to authenticate
+        that do not contain the user info fields that are always provided by auth0
+        """
+        self.assertIsNone(self.backend.authenticate())

--- a/tests/test_auth_backend.py
+++ b/tests/test_auth_backend.py
@@ -37,7 +37,7 @@ class TestDjangoAuth0(TestCase):
         self.assertRaises(ValueError, self._value_error)
 
     def _value_error(self):
-        self.auth_data['email'] = None
+        self.auth_data['user_id'] = None
         return self.backend.authenticate(**self.auth_data)
 
     def test_authenticate_ignores_non_auth0(self):


### PR DESCRIPTION
I've combined my changes into one PR so that you don't have to resolve a merge conflict.

This is to fix #4 and #5 
- I've made `AUTH0_USER_INFO_KEYS` which contains the common user info properties that will always be provided by auth0.
- `user_id` is used instead of nickname
- `email` has been dropped as a requirement as this is not always provided by auth0

I considered that a users profile could be updated at the time of authenticating, but figure this would make the authentication process needlessly complex.

Please let me know what you think.

Thanks!
